### PR TITLE
updated golang.org-x-crypto dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,11 @@ test:
 
 	go test -race -cover ./...
 .PHONY: test
+
+audit:
+	go list -json -m all | nancy sleuth
+.PHONY: audit
+
+build:
+	go build ./...
+.PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
-test:
+SHELL=bash
 
+test:
 	go test -race -cover ./...
 .PHONY: test
+
+audit:
+	go list -json -m all | nancy sleuth --exclude-vulnerability-file ./.nancy-ignore
+.PHONY: audit
+
+build:
+	go build ./...
+.PHONY: build

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: onsdigital/dp-concourse-tools-nancy
+    tag: latest
+
+inputs:
+  - name: dp-nomad
+    path: dp-nomad
+
+run:
+  path: dp-nomad/ci/scripts/audit.sh

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -1,0 +1,16 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: 1.15
+
+inputs:
+  - name: dp-nomad
+    path: dp-nomad
+
+run:
+  path: dp-nomad/ci/scripts/build.sh

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15
+    tag: latest
 
 inputs:
   - name: dp-nomad

--- a/ci/scripts/audit.sh
+++ b/ci/scripts/audit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-nomad
+  make audit
+popd

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-nomad
+  make build
+popd

--- a/ci/scripts/unit.sh
+++ b/ci/scripts/unit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-nomad
+  make test
+popd

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15
+    tag: latest
 
 inputs:
   - name: dp-nomad

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -1,0 +1,16 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: 1.15
+
+inputs:
+  - name: dp-nomad
+    path: dp-nomad
+
+run:
+  path: dp-nomad/ci/scripts/unit.sh

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/ONSdigital/dp-net v1.0.2
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/smartystreets/goconvey v1.6.4
+	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -31,7 +31,10 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
+golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -39,5 +42,6 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=


### PR DESCRIPTION
What
Updated dependency (golang.org/x/crypto) due to vulnerability CVE-2019-11840

How to review
I checked the the tests passed.

Who can review
Anyone